### PR TITLE
Add Bash script to generate active cron job list and update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # active-cronjob-list-generator
+
+**A Bash Script for Generating Active Cron Job Lists**
+
 The active-cronjob-list-generator repository contains a Bash script that generates a list of active cron jobs on a Linux system. The script parses the crontab file and extracts information about scheduled tasks, including their time, user, and command. The script is easy to use, customizable, and cross-platform compatible.
+
+**Features:**
+
+- **Simple and Efficient:** Generates a comprehensive list of active cron jobs with minimal overhead.
+- **Customizable Output:** Easily modify the output format to suit your needs.
+- **Cross-Platform Compatibility:** Runs on various Linux distributions.
+
+**Usage:**
+
+1. **Clone the Repository:**
+   ```bash
+   git clone git@github.com:AltusX1/active-cronjob-list-generator.git
+   ```
+2. **Run the Script:**
+   ```bash
+   ./active-cronjob-list-generator.sh
+    ```
+**Example Output:**
+
+   ```bash
+   mi   h   d   m   w   user    command
+   0    0   *   *   *   root    /usr/sbin/ntpdate pool.ntp.org
+   15   10  *   *   1   user1   /path/to/script.sh
+   ```
+**Customization:**
+
+You can customize the output format by modifying the script's printing logic. For example, you can add headers or change the order of fields.
+
+**License:**
+
+This project is licensed under the MIT License.

--- a/active-cronjob-list-generator.sh
+++ b/active-cronjob-list-generator.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# System-wide crontab file and cron job directory. Change these for your system if necessary.
+CRONTAB='/etc/crontab'
+CRONDIR='/etc/cron.d'
+
+# Single tab character.
+tab=$(echo -en "\t")
+
+# Given a stream of crontab lines, exclude non-cron job lines, replace
+# whitespace characters with a single space, and remove any spaces from the
+# beginning of each line.
+function clean_cron_lines() {
+    while read line ; do
+        echo "${line}" |
+            egrep --invert-match '^($|\s*#|\s*[[:alnum:]_]+=)' |
+            sed --regexp-extended "s/\s+/ /g" |
+            sed --regexp-extended "s/^ //"
+    done;
+}
+
+# Given a stream of cleaned crontab lines, echo any that don't include the
+# run-parts command, and for those that do, show each job file in the run-parts
+# directory as if it were scheduled explicitly.
+function lookup_run_parts() {
+    while read line ; do
+        match=$(echo "${line}" | egrep -o 'run-parts (-{1,2}\S+ )*\S+')
+
+        if [[ -z "${match}" ]] ; then
+            echo "${line}"
+        else
+            cron_fields=$(echo "${line}" | cut -f1-6 -d' ')
+            cron_job_dir=$(echo  "${match}" | awk '{print $NF}')
+
+            if [[ -d "${cron_job_dir}" ]] ; then
+                for cron_job_file in "${cron_job_dir}"/* ; do  # */ <not a comment>
+                    [[ -f "${cron_job_file}" ]] && echo "${cron_fields} ${cron_job_file}"
+                done
+            fi
+        fi
+    done;
+}
+
+# Temporary file for crontab lines.
+temp=$(mktemp) || exit 1
+
+# Add all of the jobs from the system-wide crontab file.
+cat "${CRONTAB}" | clean_cron_lines | lookup_run_parts >"${temp}"
+
+# Add all of the jobs from the system-wide cron directory.
+cat "${CRONDIR}"/* | clean_cron_lines >>"${temp}"  # */ <not a comment>
+
+# Add each user's crontab (if it exists). Insert the user's name between the
+# five time fields and the command.
+while read user ; do
+    crontab -l -u "${user}" 2>/dev/null |
+        clean_cron_lines |
+        sed --regexp-extended "s/^((\S+ +){5})(.+)$/\1${user} \3/" >>"${temp}"
+done < <(cut --fields=1 --delimiter=: /etc/passwd)
+
+# Output the collected crontab lines. Replace the single spaces between the
+# fields with tab characters, sort the lines by hour and minute, insert the
+# header line, and format the results as a table.
+cat "${temp}" |
+    sed --regexp-extended "s/^(\S+) +(\S+) +(\S+) +(\S+) +(\S+) +(\S+) +(.*)$/\1\t\2\t\3\t\4\t\5\t\6\t\7/" |
+    sort --numeric-sort --field-separator="${tab}" --key=2,1 |
+    sed "1i\mi\th\td\tm\tw\tuser\tcommand" |
+    column -s"${tab}" -t
+
+rm --force "${temp}"


### PR DESCRIPTION
`feature:` Add Bash script to generate active cron job list and update README.md

This commit introduces a new Bash script (`active-cronjob-list-generator.sh`) 
that generates a list of active cron jobs from the user's crontab file. 

Additionally, the README.md file has been updated to reflect the new script, 
including usage instructions and a brief overview of its functionality.